### PR TITLE
Bugfix in close: handle no-blobs case

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const { Writable, Readable } = require('streamx')
 const unixPathResolve = require('unix-path-resolve')
 const MirrorDrive = require('mirror-drive')
 const ReadyResource = require('ready-resource')
+const safetyCatch = require('safety-catch')
 
 module.exports = class Hyperdrive extends ReadyResource {
   constructor (corestore, key, opts = {}) {
@@ -86,17 +87,19 @@ module.exports = class Hyperdrive extends ReadyResource {
 
   async _close () {
     if (this._batching) return this.files.close()
-
     try {
-      if (this._checkout === null || this.blobs !== this._checkout.blobs) await this.blobs.core.close()
+      if (this._checkout === null || this.blobs !== this._checkout.blobs) await this.blobs?.core.close()
       await this.db.close()
-    } catch {}
+    } catch (e) {
+      safetyCatch(e)
+    }
 
     if (this._checkout) return
-
     try {
       await this.corestore.close()
-    } catch {}
+    } catch (e) {
+      safetyCatch(e)
+    }
   }
 
   async _openBlobsFromHeader (opts) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ module.exports = class Hyperdrive extends ReadyResource {
   async _close () {
     if (this._batching) return this.files.close()
     try {
-      if (this._checkout === null || this.blobs !== this._checkout.blobs) await this.blobs?.core.close()
+      if (this.blobs !== null && (this._checkout === null || this.blobs !== this._checkout.blobs)) {
+        await this.blobs.core.close()
+      }
       await this.db.close()
     } catch (e) {
       safetyCatch(e)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "is-options": "^1.0.2",
     "mirror-drive": "^1.2.0",
     "ready-resource": "^1.0.0",
+    "safety-catch": "^1.0.2",
     "streamx": "^2.12.4",
     "unix-path-resolve": "^1.0.2"
   },

--- a/test.js
+++ b/test.js
@@ -671,6 +671,18 @@ test('drive.close()', async (t) => {
   await drive.close()
 })
 
+test('drive.close() for future checkout', async (t) => {
+  const { drive } = await testenv(t.teardown)
+  await drive.put('some', 'thing')
+  const checkout = drive.checkout(drive.length + 1)
+  await checkout.close()
+
+  t.is(checkout.closed, true)
+  t.is(checkout.db.core.closed, true)
+  t.is(drive.closed, false)
+  t.is(drive.db.core.closed, false)
+})
+
 test.skip('drive.findingPeers()', async (t) => {
   const { drive, corestore, swarm, mirror } = await testenv(t.teardown)
   await drive.put('/', b4a.from('/'))


### PR DESCRIPTION
Blobs is not always set (see test for example, with a future checkout)

Also added safety catch (would have thrown on this `TypeError`, so easier to catch such programming/logic errors, but can revert to swallowing everything)